### PR TITLE
[Fix] 角度データ一括リスト作成

### DIFF
--- a/arm_inverse.py
+++ b/arm_inverse.py
@@ -54,6 +54,9 @@ class ARMS:
         self.sca = self.det / self.div
 
     def Moving(self):
+        # angles_trainsition (to return)
+        self.angles_trainsition = []
+
         for D in range(1, self.div+1, 1):
             # target_rads
             target = self.fst_place + self.sca*D
@@ -76,14 +79,26 @@ class ARMS:
             # now_place
             self.place = self.Rad_to_Place(self.angle)
 
-            # print(move)
+            # radians_to_degree
             _degs = self.Degree_to_Radian(self.angle, False, True)
             _posi = self.Degree_to_Radian(self.place, False, False)
+            
+            # change_range -180 ~ 180
             _degs_180 = []
             for _i in _degs:
                 if _i%360 <= 180: _degs_180.append(_i%360)
                 else:             _degs_180.append(_i%360-360)
+            
+            # append_to_return
+            self.angles_trainsition.append(_degs_180)
+
+            # print
             print(self.prints.format(D, _degs_180[0], _degs_180[1], _degs_180[2], _posi[0], _posi[1], _posi[2]%360))
+        
+        # list_to_NpData
+        self.angles_trainsition = np.array(self.angles_trainsition)
+
+        # reset_start_position
         self.first_angle = self.angle
 
 
@@ -126,3 +141,5 @@ while True:
 
     # 計算を実行( .Moving()) ※引数はなし
     arms.Moving()
+
+    print(arms.angles_trainsition)


### PR DESCRIPTION
・今までは、角度データを1回1回表示して、履歴が残らない形だった。
・この変更で、分割回数目ごとの角度データを1つのndarrayで取得できるようにした。

# 変更の目的
・分割時のそれぞれの角度データを一括で取得したかったため、すべての移動中の角度データをNdarrayに格納した

--------------------------------------

# レビュー完了希望日

レビュー完了希望日時は以下の通りです。

### 2021/9/28

お忙しい中恐れ入りますが、確認よろしくお願いいたします。

>難しそうであれば、コメントの方に理由をお願いします
-------------------------------------

# 達成条件

・特になし

# 関連commit

・ 
>
# 関連Issue

#

--------------------------------------

# After merge
Fix #

--------------------------------------